### PR TITLE
Feat/api calls

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,15 @@
+import { apiCalls } from './utilities/apiCalls';
 import logo from './logo.svg';
 import './App.css';
+import { useEffect } from 'react';
 
 function App() {
+
+  useEffect(() => {
+    apiCalls.homePageLoad()
+    .then(data => console.log(data.results))
+  })
+
   return (
     <div className="App">
       <header className="App-header">

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -13,4 +13,16 @@ export const apiCalls = {
             .catch(err => err)
     },
 
+    sectionLoad: (section) => {
+        return fetch(`https://api.nytimes.com/svc/topstories/v2/${section}.json?api-key=${key}`)
+            .then(res => {
+                if(res.ok) {
+                    return res.json()
+                } else {
+                    throw new Error()
+                }
+            })
+            .catch(err => err)
+    }
+
 }

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -1,1 +1,16 @@
 const key = '0JUSpi2WsHgz1Ni61wAut6y1KVMhXLRA'
+
+export const apiCalls = {
+    homePageLoad: () => {
+        return fetch(`https://api.nytimes.com/svc/topstories/v2/home.json?api-key=${key}`)
+            .then(res => {
+                if(res.ok) {
+                    return res.json()
+                } else {
+                    throw new Error()
+                }
+            })
+            .catch(err => err)
+    },
+
+}

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -1,0 +1,1 @@
+const key = '0JUSpi2WsHgz1Ni61wAut6y1KVMhXLRA'


### PR DESCRIPTION
What (if any) features are you implementing?
 - implemented utilities directory along with apiCalls.js file
 - apiCalls.js file now contains an object with methods related to the two currently needed fetch calls:
   - loading articles at the home page view (default fetch that runs on load)
   - loading articles based on provided section (this will eventually work by selecting a category from the header and running a new fetch call based on user selection AFTER page load)

What (if anything) did you refactor?
 - N/A

Were there any issues that arose?
 - N/A

Any other comments, questions, or concerns?
 - None at this time. This is just laying ground work. 
